### PR TITLE
Make room connection logic more robust

### DIFF
--- a/components/app.tsx
+++ b/components/app.tsx
@@ -42,24 +42,80 @@ export function App({ appConfig }: AppProps) {
     };
   }, [room, refreshConnectionDetails]);
 
+  // 1. Connect to the room
+  const [connected, setConnected] = useState(false);
   useEffect(() => {
-    if (sessionStarted && room.state === 'disconnected' && connectionDetails) {
-      Promise.all([
-        room.localParticipant.setMicrophoneEnabled(true, undefined, {
-          preConnectBuffer: appConfig.isPreConnectBufferEnabled,
-        }),
-        room.connect(connectionDetails.serverUrl, connectionDetails.participantToken),
-      ]).catch((error) => {
+    if (!sessionStarted) {
+      return;
+    }
+    if (room.state !== 'disconnected') {
+      return;
+    }
+    if (!connectionDetails) {
+      return;
+    }
+
+    let aborted = false;
+    const connect = async () => {
+      try {
+        await room.connect(connectionDetails.serverUrl, connectionDetails.participantToken);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        if (aborted) {
+          // Once the effect has cleaned up after itself, drop any errors
+          console.error('Aborted connect error:', error);
+          return;
+        }
+        console.error('Error connecting to room:', error);
         toastAlert({
           title: 'There was an error connecting to the agent',
           description: `${error.name}: ${error.message}`,
         });
-      });
-    }
+        return;
+      }
+      setConnected(true);
+    };
+    connect();
+
     return () => {
+      aborted = true;
+      setConnected(false);
       room.disconnect();
     };
   }, [room, sessionStarted, connectionDetails, appConfig.isPreConnectBufferEnabled]);
+
+  // 2. Configure the room so it can be used to talk to the agent
+  useEffect(() => {
+    if (!connected) {
+      return;
+    }
+
+    let aborted = false;
+    const configure = async () => {
+      try {
+        await room.localParticipant.setMicrophoneEnabled(true, undefined, {
+          preConnectBuffer: appConfig.isPreConnectBufferEnabled,
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        if (aborted) {
+          // Once the effect has cleaned up after itself, drop any errors
+          console.error('Aborted config error:', error);
+          return;
+        }
+        console.error('Error configuring room:', error);
+        toastAlert({
+          title: 'There was an error connecting to the agent',
+          description: `${error.name}: ${error.message}`,
+        });
+      }
+    };
+    configure();
+
+    return () => {
+      aborted = true;
+    };
+  }, [room, connected]);
 
   const { startButtonText } = appConfig;
 


### PR DESCRIPTION
In diving into this project, there were a bunch of cases where the pre-existing room connection handling logic was resulting in errors being surfaced in the console and sometimes broken states, like the "cannot publish track" error reported by @bcherry.

I've done three main things to try to minimize these issues:
1. ~Make `room.connect()` and `room.localParticipant.setMicrophoneEnabled(...)` run in series, not parallel. Reading the code for the latter function in depth. it seems like there's a race condition where the room must be set up by the time execution gets about half way through `setMicrophoneEnabled` and if it isn't initialized in time `setMicrophoneEnabled` throws [an error](https://github.com/livekit/client-sdk-js/blob/b3ac2ace6a693ea04818406835feab195f551d91/src/room/participant/LocalParticipant.ts#L1165).~ (per discussion below, this is no longer in here)

2. ~Split the existing `useEffect` up into two, one that handles connecting / disconnecting, and one that handles "room configuration" (right now just `room.localParticipant.setMicrophoneEnabled`). This ensures that if a user disconnects halfway through execution of `room.connect()`, the room configuration logic doesn't run.~ (per discussion below, this is no longer in here)

3. Add some local effect state to track if if either have been aborted, and don't reraise any errors beyond that point. This is because of cases like [this](https://github.com/livekit/client-sdk-js/blob/fb132fbdabd31e1d0670731c8cea627a2014811c/src/room/Room.ts#L1000-L1007) where errors are raised to stop execution flow.