### PR TITLE
Disable debug logs by default

### DIFF
--- a/components/session-view.tsx
+++ b/components/session-view.tsx
@@ -39,7 +39,8 @@ export const SessionView = ({
   const { messages, send } = useChatAndTranscription();
   const room = useRoomContext();
 
-  useDebugMode();
+  // Uncomment the below to see verbose logs showing the underlying connection lifecycle
+  // useDebugMode();
 
   async function handleSendMessage(message: string) {
     await send(message);

--- a/components/session-view.tsx
+++ b/components/session-view.tsx
@@ -14,7 +14,7 @@ import { ChatEntry } from '@/components/livekit/chat/chat-entry';
 import { ChatMessageView } from '@/components/livekit/chat/chat-message-view';
 import { MediaTiles } from '@/components/livekit/media-tiles';
 import useChatAndTranscription from '@/hooks/useChatAndTranscription';
-import { useDebugMode } from '@/hooks/useDebug';
+// import { useDebugMode } from '@/hooks/useDebug';
 import type { AppConfig } from '@/lib/types';
 import { cn } from '@/lib/utils';
 

--- a/components/session-view.tsx
+++ b/components/session-view.tsx
@@ -14,7 +14,7 @@ import { ChatEntry } from '@/components/livekit/chat/chat-entry';
 import { ChatMessageView } from '@/components/livekit/chat/chat-message-view';
 import { MediaTiles } from '@/components/livekit/media-tiles';
 import useChatAndTranscription from '@/hooks/useChatAndTranscription';
-// import { useDebugMode } from '@/hooks/useDebug';
+import { useDebugMode } from '@/hooks/useDebug';
 import type { AppConfig } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
@@ -39,8 +39,9 @@ export const SessionView = ({
   const { messages, send } = useChatAndTranscription();
   const room = useRoomContext();
 
-  // Uncomment the below to see verbose logs showing the underlying connection lifecycle
-  // useDebugMode();
+  useDebugMode({
+    enabled: process.env.NODE_END !== 'production',
+  });
 
   async function handleSendMessage(message: string) {
     await send(message);

--- a/hooks/useDebug.ts
+++ b/hooks/useDebug.ts
@@ -2,10 +2,17 @@ import * as React from 'react';
 import { LogLevel, setLogLevel } from 'livekit-client';
 import { useRoomContext } from '@livekit/components-react';
 
-export const useDebugMode = ({ logLevel }: { logLevel?: LogLevel } = {}) => {
+export const useDebugMode = (options: { logLevel?: LogLevel; enabled?: boolean } = {}) => {
   const room = useRoomContext();
+  const logLevel = options.logLevel ?? 'debug';
+  const enabled = options.enabled ?? true;
 
   React.useEffect(() => {
+    if (!enabled) {
+      setLogLevel('silent');
+      return;
+    }
+
     setLogLevel(logLevel ?? 'debug');
 
     // @ts-expect-error
@@ -14,6 +21,7 @@ export const useDebugMode = ({ logLevel }: { logLevel?: LogLevel } = {}) => {
     return () => {
       // @ts-expect-error
       window.__lk_room = undefined;
+      setLogLevel('silent');
     };
-  }, [room, logLevel]);
+  }, [room, enabled, logLevel]);
 };


### PR DESCRIPTION
@bcherry made the comment that this app's debug logs are too noisy by default. However, it seems like they could be useful for somebody who is developing with the app or otherwise making changes. So, disable them by default in production (via `NODE_ENV`), but leave the opportunity open for one to hardcode the `enabled` value to `true`/`false` to get them back again.