### PR TITLE
feat: add support for explicit agent dispatch via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ agent-starter-react/
 > [!TIP]
 > If you'd like to try this application without modification, you can deploy an instance in just a few clicks with [LiveKit Cloud Sandbox](https://cloud.livekit.io/projects/p_/sandbox/templates/agent-starter-react).
 
-[![Open on LiveKit](https://img.shields.io/badge/Open%20on%20LiveKit%20Cloud-002CF2?style=for-the-badge&logo=external-link)](https://cloud.livekit.io/projects/p_/sandbox/templates/voice-assistant-frontend)
+[![Open on LiveKit](https://img.shields.io/badge/Open%20on%20LiveKit%20Cloud-002CF2?style=for-the-badge&logo=external-link)](https://cloud.livekit.io/projects/p_/sandbox/templates/agent-starter-react)
 
 Run the following command to automatically clone this template.
 
 ```bash
-lk app create --template voice-assistant-frontend
+lk app create --template agent-starter-react
 ```
 
 Then run the app with:

--- a/app-config.ts
+++ b/app-config.ts
@@ -15,4 +15,6 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
   logoDark: '/lk-logo-dark.svg',
   accentDark: '#1fd5f9',
   startButtonText: 'Start call',
+
+  agentName: undefined,
 };

--- a/app/api/connection-details/route.ts
+++ b/app/api/connection-details/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { AccessToken, type AccessTokenOptions, type VideoGrant } from 'livekit-server-sdk';
+import { RoomConfiguration } from '@livekit/protocol';
 
 // NOTE: you are expected to define the following environment variables in `.env.local`:
 const API_KEY = process.env.LIVEKIT_API_KEY;
@@ -81,12 +82,9 @@ function createParticipantToken(
   at.addGrant(grant);
 
   if (agentName) {
-    at.roomConfig = {
-      agents: [
-        // @ts-expect-error - RoomAgentDispatch is not constructable
-        { agentName },
-      ],
-    };
+    at.roomConfig = new RoomConfiguration({
+      agents: [{ agentName }],
+    });
   }
 
   return at.toJwt();

--- a/app/components/Tabs.tsx
+++ b/app/components/Tabs.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+export function Tabs() {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex flex-row justify-between border-b">
+      <Link
+        href="/components/base"
+        className={cn(
+          'text-fg0 -mb-px cursor-pointer px-4 pt-2 text-xl font-bold tracking-tight uppercase',
+          pathname === '/components/base' && 'bg-background rounded-t-lg border-t border-r border-l'
+        )}
+      >
+        Base components
+      </Link>
+      <Link
+        href="/components/livekit"
+        className={cn(
+          'text-fg0 -mb-px cursor-pointer px-4 py-2 text-xl font-bold tracking-tight uppercase',
+          pathname === '/components/livekit' &&
+            'bg-background rounded-t-lg border-t border-r border-l'
+        )}
+      >
+        LiveKit components
+      </Link>
+    </div>
+  );
+}

--- a/app/components/layout.tsx
+++ b/app/components/layout.tsx
@@ -1,39 +1,12 @@
-'use client';
-
 import * as React from 'react';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { Room } from 'livekit-client';
-import { RoomContext } from '@livekit/components-react';
-import { toastAlert } from '@/components/alert-toast';
-import useConnectionDetails from '@/hooks/useConnectionDetails';
-import { cn } from '@/lib/utils';
+import { headers } from 'next/headers';
+import { Tabs } from '@/app/components/Tabs';
+import { Provider } from '@/components/provider';
+import { cn, getAppConfig } from '@/lib/utils';
 
-export default function ComponentsLayout({ children }: { children: React.ReactNode }) {
-  const { connectionDetails } = useConnectionDetails();
-
-  const pathname = usePathname();
-  const room = React.useMemo(() => new Room(), []);
-
-  React.useEffect(() => {
-    if (room.state === 'disconnected' && connectionDetails) {
-      Promise.all([
-        room.localParticipant.setMicrophoneEnabled(true, undefined, {
-          preConnectBuffer: true,
-        }),
-        room.connect(connectionDetails.serverUrl, connectionDetails.participantToken),
-      ]).catch((error) => {
-        toastAlert({
-          title: 'There was an error connecting to the agent',
-          description: `${error.name}: ${error.message}`,
-        });
-      });
-    }
-    return () => {
-      room.disconnect();
-    };
-  }, [room, connectionDetails]);
-
+export default async function ComponentsLayout({ children }: { children: React.ReactNode }) {
+  const hdrs = await headers();
+  const appConfig = await getAppConfig(hdrs);
   return (
     <div className="mx-auto min-h-svh max-w-3xl space-y-8 px-4 py-8">
       <header className="flex flex-col gap-1">
@@ -42,33 +15,10 @@ export default function ComponentsLayout({ children }: { children: React.ReactNo
           A quick start UI overview for the LiveKit Voice Assistant.
         </p>
       </header>
-
-      <div className="flex flex-row justify-between border-b">
-        <Link
-          href="/components/base"
-          className={cn(
-            'text-fg0 -mb-px cursor-pointer px-4 pt-2 text-xl font-bold tracking-tight uppercase',
-            pathname === '/components/base' &&
-              'bg-background rounded-t-lg border-t border-r border-l'
-          )}
-        >
-          Base components
-        </Link>
-        <Link
-          href="/components/livekit"
-          className={cn(
-            'text-fg0 -mb-px cursor-pointer px-4 py-2 text-xl font-bold tracking-tight uppercase',
-            pathname === '/components/livekit' &&
-              'bg-background rounded-t-lg border-t border-r border-l'
-          )}
-        >
-          LiveKit components
-        </Link>
-      </div>
-
-      <RoomContext.Provider value={room}>
+      <Tabs />
+      <Provider appConfig={appConfig}>
         <main className="flex w-full flex-1 flex-col items-stretch gap-8">{children}</main>
-      </RoomContext.Provider>
+      </Provider>
     </div>
   );
 }

--- a/components/app.tsx
+++ b/components/app.tsx
@@ -21,7 +21,8 @@ interface AppProps {
 export function App({ appConfig }: AppProps) {
   const room = useMemo(() => new Room(), []);
   const [sessionStarted, setSessionStarted] = useState(false);
-  const { refreshConnectionDetails, existingOrRefreshConnectionDetails } = useConnectionDetails();
+  const { refreshConnectionDetails, existingOrRefreshConnectionDetails } =
+    useConnectionDetails(appConfig);
 
   useEffect(() => {
     const onDisconnected = () => {

--- a/components/pathname.tsx
+++ b/components/pathname.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+export function Pathname({ action }: { action: (pathname: string) => React.ReactNode }) {
+  const pathname = usePathname();
+  return <>{action(pathname)}</>;
+}

--- a/components/pathname.tsx
+++ b/components/pathname.tsx
@@ -1,8 +1,0 @@
-'use client';
-
-import { usePathname } from 'next/navigation';
-
-export function Pathname({ action }: { action: (pathname: string) => React.ReactNode }) {
-  const pathname = usePathname();
-  return <>{action(pathname)}</>;
-}

--- a/components/provider.tsx
+++ b/components/provider.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import { Room } from 'livekit-client';
+import { RoomContext } from '@livekit/components-react';
+import { toastAlert } from '@/components/alert-toast';
+import useConnectionDetails from '@/hooks/useConnectionDetails';
+import { AppConfig } from '@/lib/types';
+
+export function Provider({
+  appConfig,
+  children,
+}: {
+  appConfig: AppConfig;
+  children: React.ReactNode;
+}) {
+  const { connectionDetails } = useConnectionDetails(appConfig);
+  const room = React.useMemo(() => new Room(), []);
+
+  React.useEffect(() => {
+    if (room.state === 'disconnected' && connectionDetails) {
+      Promise.all([
+        room.localParticipant.setMicrophoneEnabled(true, undefined, {
+          preConnectBuffer: true,
+        }),
+        room.connect(connectionDetails.serverUrl, connectionDetails.participantToken),
+      ]).catch((error) => {
+        toastAlert({
+          title: 'There was an error connecting to the agent',
+          description: `${error.name}: ${error.message}`,
+        });
+      });
+    }
+    return () => {
+      room.disconnect();
+    };
+  }, [room, connectionDetails]);
+
+  return <RoomContext.Provider value={room}>{children}</RoomContext.Provider>;
+}

--- a/hooks/useConnectionDetails.ts
+++ b/hooks/useConnectionDetails.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { decodeJwt } from 'jose';
 import { ConnectionDetails } from '@/app/api/connection-details/route';
+import { AppConfig } from '@/lib/types';
 
 const ONE_MINUTE_IN_MILLISECONDS = 60 * 1000;
 
-export default function useConnectionDetails() {
+export default function useConnectionDetails(appConfig: AppConfig) {
   // Generate room connection details, including:
   //   - A random Room name
   //   - A random Participant name
@@ -25,7 +26,20 @@ export default function useConnectionDetails() {
 
     let data: ConnectionDetails;
     try {
-      const res = await fetch(url.toString());
+      const res = await fetch(url.toString(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Sandbox-Id': appConfig.sandboxId ?? '',
+        },
+        body: JSON.stringify({
+          room_config: appConfig.agentName
+            ? {
+                agents: [{ agent_name: appConfig.agentName }],
+              }
+            : undefined,
+        }),
+      });
       data = await res.json();
     } catch (error) {
       console.error('Error fetching connection details:', error);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,6 +22,9 @@ export interface AppConfig {
   accent?: string;
   logoDark?: string;
   accentDark?: string;
+
+  sandboxId?: string;
+  agentName?: string;
 }
 
 export interface SandboxConfig {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -54,8 +54,11 @@ export const getAppConfig = cache(async (headers: Headers): Promise<AppConfig> =
 
       for (const [key, entry] of Object.entries(remoteConfig)) {
         if (entry === null) continue;
+        // Only include app config entries that are declared in defaults and, if set,
+        // share the same primitive type as the default value.
         if (
-          (key in config && config[key as keyof AppConfig] === undefined) ||
+          (key in APP_CONFIG_DEFAULTS &&
+            APP_CONFIG_DEFAULTS[key as keyof AppConfig] === undefined) ||
           (typeof config[key as keyof AppConfig] === entry.type &&
             typeof config[key as keyof AppConfig] === typeof entry.value)
         ) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -50,14 +50,14 @@ export const getAppConfig = cache(async (headers: Headers): Promise<AppConfig> =
       });
 
       const remoteConfig: SandboxConfig = await response.json();
-      const config: AppConfig = { ...APP_CONFIG_DEFAULTS };
+      const config: AppConfig = { sandboxId, ...APP_CONFIG_DEFAULTS };
 
       for (const [key, entry] of Object.entries(remoteConfig)) {
         if (entry === null) continue;
         if (
-          key in config &&
-          typeof config[key as keyof AppConfig] === entry.type &&
-          typeof config[key as keyof AppConfig] === typeof entry.value
+          (key in config && config[key as keyof AppConfig] === undefined) ||
+          (typeof config[key as keyof AppConfig] === entry.type &&
+            typeof config[key as keyof AppConfig] === typeof entry.value)
         ) {
           // @ts-expect-error I'm not sure quite how to appease TypeScript, but we've thoroughly checked types above
           config[key as keyof AppConfig] = entry.value as AppConfig[keyof AppConfig];

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@livekit/components-react": "^2.9.9",
+    "@livekit/components-react": "^2.9.14",
+    "@livekit/protocol": "^1.40.0",
     "@phosphor-icons/react": "^2.1.8",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-scroll-area": "^1.2.9",
@@ -23,8 +24,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "jose": "^6.0.12",
-    "livekit-client": "^2.13.3",
-    "livekit-server-sdk": "^2.13.0",
+    "livekit-client": "^2.15.5",
+    "livekit-server-sdk": "^2.13.2",
     "mime": "^4.0.7",
     "motion": "^12.16.0",
     "next": "15.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,11 @@ importers:
   .:
     dependencies:
       '@livekit/components-react':
-        specifier: ^2.9.9
+        specifier: ^2.9.14
         version: 2.9.14(@livekit/krisp-noise-filter@0.2.16(livekit-client@2.15.5(@types/dom-mediacapture-record@1.0.22)))(livekit-client@2.15.5(@types/dom-mediacapture-record@1.0.22))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tslib@2.8.1)
+      '@livekit/protocol':
+        specifier: ^1.40.0
+        version: 1.40.0
       '@phosphor-icons/react':
         specifier: ^2.1.8
         version: 2.1.10(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -45,10 +48,10 @@ importers:
         specifier: ^6.0.12
         version: 6.0.12
       livekit-client:
-        specifier: ^2.13.3
+        specifier: ^2.15.5
         version: 2.15.5(@types/dom-mediacapture-record@1.0.22)
       livekit-server-sdk:
-        specifier: ^2.13.0
+        specifier: ^2.13.2
         version: 2.13.2
       mime:
         specifier: ^4.0.7
@@ -440,6 +443,9 @@ packages:
 
   '@livekit/protocol@1.39.3':
     resolution: {integrity: sha512-hfOnbwPCeZBEvMRdRhU2sr46mjGXavQcrb3BFRfG+Gm0Z7WUSeFdy5WLstXJzEepz17Iwp/lkGwJ4ZgOOYfPuA==}
+
+  '@livekit/protocol@1.40.0':
+    resolution: {integrity: sha512-1q0TNqlSTDW9ZuQCYTLDusyO+StvAXPmECQgyuszThDjzhTwQOkA6Rv7B1wPcvpTcwieIG0vuAO4cw4+kg+xWA==}
 
   '@napi-rs/wasm-runtime@0.2.10':
     resolution: {integrity: sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==}
@@ -2971,6 +2977,10 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 
+  '@livekit/protocol@1.40.0':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
+
   '@napi-rs/wasm-runtime@0.2.10':
     dependencies:
       '@emnapi/core': 1.4.3
@@ -4589,7 +4599,7 @@ snapshots:
   livekit-server-sdk@2.13.2:
     dependencies:
       '@bufbuild/protobuf': 1.10.1
-      '@livekit/protocol': 1.39.3
+      '@livekit/protocol': 1.40.0
       camelcase-keys: 9.1.3
       jose: 5.10.0
 


### PR DESCRIPTION
Refactors some code such that we can extract `agentName` off the app config and use it to add explicit dispatch when generating a token, either locally or via sandbox token endpoint.

Depends on https://github.com/livekit/cloud-api-server/pull/1255 to work in sandbox mode

https://linear.app/livekit/issue/DEVPROD-448/update-hosted-agent-playground-with-agent-name-support